### PR TITLE
fix(sourcereader.ts): the method `toString` of `SourcePosition` was made consistent. Closing #25

### DIFF
--- a/src/SourceReader/SourceReader.ts
+++ b/src/SourceReader/SourceReader.ts
@@ -201,7 +201,7 @@ export class UnknownSourcePosition extends SourcePosition {
      * @group API: Access
      */
     public toString(): string {
-        return '<' + intl.translate('string.UnknownPosition') + '>';
+        return '@<' + intl.translate('string.UnknownPosition') + '>';
     }
     // ------------------
     // #endregion } API: Access
@@ -688,7 +688,7 @@ export class EndOfInputSourcePosition extends KnownSourcePosition {
      * @group API: Access
      */
     public toString(): string {
-        return '<' + intl.translate('string.EndOfInput') + '>';
+        return '@<' + intl.translate('string.EndOfInput') + '>';
     }
     // ------------------
     // #endregion } API: Access
@@ -1146,7 +1146,7 @@ export class EndOfDocumentSourcePosition extends DocumentSourcePosition {
      * @group API: Access
      */
     public toString(): string {
-        return '<' + intl.translate('string.EndOfDocument') + '>';
+        return '@<' + intl.translate('string.EndOfDocument') + '>';
     }
     // ------------------
     // #endregion } API: Access
@@ -1226,7 +1226,15 @@ export class DefinedSourcePosition extends DocumentSourcePosition {
      * @group API: Access
      */
     public toString(): string {
-        return `${this.documentName}@${this._line}:${this._column}`;
+        return (
+            '@<' +
+            this.documentName +
+            (this.documentName === '' ? '' : ':') +
+            this._line +
+            ',' +
+            this._column +
+            '>'
+        );
     }
     // ------------------
     // #endregion } API: Access

--- a/test/SourceReader/SourceReader.test.ts
+++ b/test/SourceReader/SourceReader.test.ts
@@ -183,7 +183,9 @@ function verifyPositionKnown(
         expect(posArg.documentName).toBe(inputNameArg);
         expect(posArg.visibleDocumentContents).toBe(vInpContsArg);
         expect(posArg.fullDocumentContents).toBe(inpContsArg);
-        expect(posArg.toString()).toBe(inputNameArg + '@' + linArg + ':' + colArg);
+        expect(posArg.toString()).toBe(
+            '@<' + inputNameArg + (inputNameArg === '' ? '' : ':') + linArg + ',' + colArg + '>'
+        );
     }
 }
 
@@ -196,7 +198,7 @@ function verifyEmptyFileInSourceReader(readerArg: SR.SourceReader): void {
     pos = readerArg.getPosition();
     expect(pos.isEndOfInput()).toBe(false);
     expect((pos as SR.DocumentSourcePosition).isEndOfDocument()).toBe(true);
-    expect(pos.toString()).toBe('<' + intl.translate('string.EndOfDocument') + '>');
+    expect(pos.toString()).toBe('@<' + intl.translate('string.EndOfDocument') + '>');
     verifyPositionKnown(pos, readerArg, 1, 1, []); // Satisfy all the position methods
 }
 
@@ -246,7 +248,7 @@ describe('SourceReader static members', () => {
     it('SR.static - Unknown position', () => {
         const posU: SR.UnknownSourcePosition = SR.SourceReader.UnknownPosition;
         expect(posU.isUnknown()).toBe(true);
-        expect(posU.toString()).toBe('<' + intl.translate('string.UnknownPosition') + '>');
+        expect(posU.toString()).toBe('@<' + intl.translate('string.UnknownPosition') + '>');
     });
 });
 
@@ -823,7 +825,7 @@ describe('Contents from SourceReader array 1, single line', () => {
             expect(pos2.isEndOfInput()).toBe(true);
             expect(reader.startsWith('')).toBe(true);
             expect(reader.startsWith('any')).toBe(false);
-            expect(pos2.toString()).toBe('<' + intl.translate('string.EndOfInput') + '>');
+            expect(pos2.toString()).toBe('@<' + intl.translate('string.EndOfInput') + '>');
             vConts = input as string;
             fConts = input as string;
             verifyContents();


### PR DESCRIPTION
The method `toString` of `SourcePosition` was fixed to has a consistent use of '@' and '<>' deliminters.
