### PR TITLE
feat(sourcereader): added contextual contents operations to DocumentPositions, close #31

### DIFF
--- a/src/SourceReader/SourceReader.ts
+++ b/src/SourceReader/SourceReader.ts
@@ -20,7 +20,7 @@ import { SourceReaderIntl as intl } from './translations';
 // ===============================================
 
 // ===============================================
-// #region API: Main -- Source Input {
+// #region Main definitions -- Source Input {
 // -----------------------------------------------
 /**
  * A Source Input is composed of one or more 'documents', that may be obtained (and identified)
@@ -52,39 +52,35 @@ import { SourceReaderIntl as intl } from './translations';
  *    ```
  *    new SourceReader(input, '\n');
  *    ```
- * @group API: Main
+ * @group Main definitions
  */
 export type SourceInput = string | Record<string, string> | string[];
 // -----------------------------------------------
-// #endregion } API: Main -- Source Input
+// #endregion } Main defintions -- Source Input
 // ===============================================
 
 // ===============================================
-// #region API: Main -- SourcePositions {
+// #region SourcePositions {
 // -----------------------------------------------
 /**
- * Instances of {@link SourcePosition} point to particular positions in the source given by a
- * {@link SourceReader}.
- * They may be unknown or they may point to a particular position into a {@link SourceReader}.
- * All {@link SourcePosition} are created through {@link SourceReader}.
+ * {@link SourcePosition}s conform a hierarchy of subclasses, as positions may be unknown or
+ * they may point to a particular position into a {@link SourceReader}.
+ * All {@link SourcePosition}s are created only through {@link SourceReader}.
  *
+ * The general class is precisely {@link SourcePosition}, an abstract class to represent all
+ * possible positions.
  * Subclasses of {@link SourcePosition} determine if the position is known or unknown, and in
  * the case of being known, which kind of position it is.
- * The operation {@link SourcePosition.isUnknown | isUnknown} indicates which is the case.
- * Additionally, all {@link SourcePosition} can be converted to a string, for showing
- * purposes, with the operation {@link SourcePosition.toString | toString}.
+ * All positions know the following operations:
+ *  * {@link SourcePosition.isUnknown | isUnknown} indicating if the position is known or not.
+ *  * {@link SourcePosition.toString | toString}, converting the position to a string, for
+ *    showing purposes (**not** for persistence).
  * Subclasses may have other operations, depending on its nature.
- *
- * Valid operations on a {@link SourcePosition} include:
- *  * indicate if the position is known or unknown, with
- *    {@link SourcePosition.isUnknown | isUnknown}, and
- *  * produce a string representation of the position for display (**not** for persistence),
- *    with {@link SourcePosition.toString | toString}.
  *
  * A typical use of {@link SourcePosition} is relating nodes of an AST representation of code to
  * particular positions in the string version of the source code (that may come from several input
  * documents).
- * @group API: Source Positions
+ * @group Main definitions
  */
 export abstract class SourcePosition {
     // ==================
@@ -145,7 +141,7 @@ export abstract class SourcePosition {
  *
  * These positions responds with `true` to the operation
  * {@link SourcePosition.isUnknown | isUnknown}.
- * @group API: Source Positions
+ * @group Source Positions
  */
 export class UnknownSourcePosition extends SourcePosition {
     // ==================
@@ -209,31 +205,33 @@ export class UnknownSourcePosition extends SourcePosition {
 }
 
 /**
- * A {@link KnownSourcePosition} points to a position in a specific {@link SourceReader}.
- * It is created using the {@link SourceReader.getPosition | getPosition} operation of a
- * particular {@link SourceReader} instance.
- * The obtained object indicates a position in the source associated with that reader, that may be
- * EndOfInput (after all input documents has been processed) or a defined position (that is, one
- * that corresponds to one of the documents of the input).
- * This difference is given by subclasses.
+ * A {@link KnownSourcePosition} points to a specific position in a particular
+ * {@link SourceReader}.
+ * It is created using the {@link SourceReader.getPosition} operation of a {@link SourceReader}
+ * instance.
+ * The obtained object indicates a position in the source associated with that reader, that may
+ * be one of two possible subclasses:
+ *  * {@link EndOfInputSourcePosition}, the position occurring after all input documents has been
+ *    processed, or
+ *  * {@link DocumentSourcePosition}, one that points to one of the documents of the input.
  *
  * Valid operations on a {@link KnownSourcePosition}, in addition to those of the superclasses,
  * include:
- *  * indicate if the position is EndOfInput or not, with
- *    {@link KnownSourcePosition.isEndOfInput | isEndOfInput},
- *  * get the {@link SourceReader} this positions refers to, with
- *    {@link KnownSourcePosition.sourceReader | sourceReader},
- *  * get the line, column, and regions in the source input, with
- *    {@link KnownSourcePosition.line | line},
- *    {@link KnownSourcePosition.column | column}, and
- *    {@link KnownSourcePosition.regions | regions}, and
- *  * get the visible or full portion of the source between a known position and some other
- *    known position related with the same reader, with
- *    {@link KnownSourcePosition.visibleContentsTo | visibleContentsTo},
- *    {@link KnownSourcePosition.visibleContentsFrom | visibleContentsFrom},
- *    {@link KnownSourcePosition.fullContentsTo | fullContentsTo}, and
- *    {@link KnownSourcePosition.fullContentsFrom | fullContentsFrom}.
- * @group API: Source Positions
+ *  * {@link KnownSourcePosition.isEndOfInput}, indicating if the position is EndOfInput or not,
+ *  * {@link KnownSourcePosition.sourceReader}, getting the {@link SourceReader} the receiver
+ *    refers to,
+ *  * {@link KnownSourcePosition.line},
+ *    {@link KnownSourcePosition.column}, and
+ *    {@link KnownSourcePosition.regions}, getting the line, column, and regions in the source
+ *    input,
+ *  * {@link KnownSourcePosition.visibleContentsTo},
+ *    {@link KnownSourcePosition.visibleContentsFrom},
+ *    {@link KnownSourcePosition.fullContentsTo}, and
+ *    {@link KnownSourcePosition.fullContentsFrom}, getting the visible or full portion of the
+ *    source between a known position and some other known position related with the same reader.
+ * Subclasses may provide additional operations.
+ *
+ * @group Source Positions
  */
 export abstract class KnownSourcePosition extends SourcePosition {
     // ==================
@@ -625,7 +623,7 @@ export abstract class KnownSourcePosition extends SourcePosition {
  * That position is reached when all input documents have been processed.
  * It is a special position, because it does not point to a particular position inside a
  * document in the source input, but to the end of it.
- * @group API: Source Positions
+ * @group Source Positions
  */
 export class EndOfInputSourcePosition extends KnownSourcePosition {
     // ==================
@@ -774,21 +772,23 @@ export class EndOfInputSourcePosition extends KnownSourcePosition {
 }
 
 /**
- * A {@link DocumentSourcePosition} points to a particular position, different from EndOfInput,
- * in a source given by a {@link SourceReader}.
+ * A {@link DocumentSourcePosition} points to a particular position inside a document of
+ * the source given by a {@link SourceReader}.
  *
  * It provides the right implementation for the operations given by its superclasses,
  * {@link KnownSourcePosition} and {@link SourcePosition}.
- * Additionally, it provides three new operations that only have sense for defined positions:
- *  * {@link DocumentSourcePosition.documentName | documentName}, the name of the particular
+ * Additionally, it provides new operations that only have sense for defined positions:
+ *  * {@link DocumentSourcePosition.documentName}, the name of the particular
  *    document in the source input that has the char pointed to by this position,
- *  * {@link DocumentSourcePosition.visibleDocumentContents | visibleDocumentContents}, the visible
- *    contents of the particular document in the source input that this position points to,
- *    and
- *  * {@link DocumentSourcePosition.fullDocumentContents | fullDocumentContents}, the contents
- *    (both visible and non-visible) of the particular document in the source input that this
- *    position point to.
- * @group API: Source Positions
+ *  * {@link DocumentSourcePosition.visibleDocumentContents} and
+ *  * {@link DocumentSourcePosition.fullDocumentContents}, the visible and full
+ *    (both visible and non-visible) contents of the particular document in the source input
+ *    that this position points to, and
+ *  * {@link DocumentSourcePosition.contextBefore} and
+ *    {@link DocumentSourcePosition.contextAfter}, a given number of lines before or after the
+ *    this position in the current document (allowing for a more localized contextual reference
+ *    for the position that may be used for showing purposes).
+ * @group Source Positions
  */
 export abstract class DocumentSourcePosition extends KnownSourcePosition {
     // ==================
@@ -903,7 +903,7 @@ export abstract class DocumentSourcePosition extends KnownSourcePosition {
     // ------------------
     /**
      * The name of the input document this position belongs to.
-     * @group API: Access
+     * @group Access
      */
     public get documentName(): string {
         let name: string = this._sourceReader._documentNameAt(this._theDocumentIndex);
@@ -918,7 +918,7 @@ export abstract class DocumentSourcePosition extends KnownSourcePosition {
 
     /**
      * The contents of the visible input document this position belongs to.
-     * @group API: Access
+     * @group Access
      */
     public get visibleDocumentContents(): string {
         return this._sourceReader._visibleDocumentContentsAt(this._theDocumentIndex);
@@ -978,6 +978,31 @@ export abstract class DocumentSourcePosition extends KnownSourcePosition {
     // ==================
     // #region API: Access - 2 {
     // ------------------
+    /**
+     * Returns the full context of the source document before the position, up to the
+     * beginning of the given number of lines, or the beginning of the document, whichever
+     * comes first.
+     *
+     * The char at the given position is NOT included in the solution.
+     *
+     * @group Access
+     */
+    public contextBefore(lines: number): string {
+        return this._sourceReader._contextBeforeOf(this, lines);
+    }
+
+    /**
+     * Returns the full context of the source document after the position, up to the beginning
+     * of the given number of lines or the end of the document, whichever comes first.
+     *
+     * The char at the given position is the first one in the solution.
+     *
+     * @group Access
+     */
+    public contextAfter(lines: number): string {
+        return this._sourceReader._contextAfterOf(this, lines);
+    }
+
     /**
      * Answers if this position correspond to the end of input of the
      * {@link SourceReader} it belongs, or not.
@@ -1078,7 +1103,7 @@ export abstract class DocumentSourcePosition extends KnownSourcePosition {
  * but the source reader has not yet been advanced to the next document.
  * It is a special position, because it does not point to a particular position inside a document in
  * the source input, but to the end of one of the documents in it.
- * @group API: Source Positions
+ * @group Source Positions
  */
 export class EndOfDocumentSourcePosition extends DocumentSourcePosition {
     // ==================
@@ -1154,11 +1179,11 @@ export class EndOfDocumentSourcePosition extends DocumentSourcePosition {
 }
 
 /**
- * A {@link DefinedSourcePosition} points to a particular position, different from EndOfString,
+ * A {@link DefinedSourcePosition} points to a particular position, different from EndOfDocument,
  * in a source given by a {@link SourceReader}.
  *
  * It provides the right implementation for the operations given by its superclasses.
- * @group API: Source Positions
+ * @group Source Positions
  */
 export class DefinedSourcePosition extends DocumentSourcePosition {
     // ==================
@@ -1241,11 +1266,11 @@ export class DefinedSourcePosition extends DocumentSourcePosition {
     // ==================
 }
 // -----------------------------------------------
-// #endregion } API: Main -- SourcePositions
+// #endregion } SourcePositions
 // ===============================================
 
 // ===============================================
-// #region API: Main -- SourceReader {
+// #region Main definitions -- SourceReader {
 // -----------------------------------------------
 /**
  * A {@link SourceReader} allows you to read input from some source, either one single document of
@@ -1262,22 +1287,22 @@ export class DefinedSourcePosition extends DocumentSourcePosition {
  *
  * A {@link SourceReader} is created using a {@link SourceInput} and then {@link SourcePosition}s,
  * in particular {@link KnownSourcePosition}s, can be read from it.
- * Possible interactions with a {@link SourceReader} include:
- *  - peek a character, with {@link SourceReader.peek},
- *  - check if a given strings occurs at the beginning of the text in the current document, without
- *    skipping it, with {@link SourceReader.startsWith},
- *  - get the current position as a {@link KnownSourcePosition}, with
- *    {@link SourceReader.getPosition},
- *  - get the current position as a {@link DocumentSourcePosition}, with
- *    {@link SourceReader.getDocumentPosition}, provided the end of input was not reached,
- *  - detect if the end of input was reached, with {@link SourceReader.atEndOfInput},
- *  - detect if the end of the current document was reached, with
- *    {@link SourceReader.atEndOfDocument},
- *  - skip one or more characters, with {@link skip},
- *  - read some characters from the current document based on a condition, with {@link takeWhile},
- *    and
- *  - manipulate "regions", with {@link SourceReader.beginRegion}
- *    and {@link SourceReader.endRegion}.
+ * Possible interactions with a {@link SourceReader} includes:
+ *  - {@link SourceReader.peek | peek}, peeking a character,
+ *  - {@link SourceReader.startsWith | startsWith}, checking if a given strings occurs at the
+ *    beginning of the text in the current document, without skipping it,
+ *  - {@link SourceReader.getPosition | getPosition}
+ *  - {@link SourceReader.getDocumentPosition | getDocumentPosition}, getting the current position
+ *    as a {@link KnownSourcePosition} or (provided the end of input was not reached)
+ *    {@link DocumentSourcePosition}, respectively,
+ *  - {@link SourceReader.atEndOfInput | atEndOfInput}, detecting if the end of input was reached,
+ *  - {@link SourceReader.atEndOfDocument | atEndOfDocument}, detecting if the end of the current
+ *    document was reached,
+ *  - {@link SourceReader.skip | skip}, skipping one or more characters,
+ *  - {@link SourceReader.takeWhile | takeWhile}, reading some characters from the current document
+ *    based on a condition, and
+ *  - {@link SourceReader.beginRegion | beginRegion} and
+ *    {@link SourceReader.endRegion | endRegion}, manipulating "regions".
  * When reading from sources with multiple documents of input, skipping moves inside a document
  * until there are no more characters, then an end of document position is reached (a special
  * position just after the last character of that document), and then a new document is started.
@@ -1379,7 +1404,7 @@ export class DefinedSourcePosition extends DocumentSourcePosition {
  *       For that reason document is better to use {@link SourceReader.startsWith} to verify
  *       if the input starts with some character (or string), when peeking for something
  *       specific.
- * @group API: Main
+ * @group Main definitions
  */
 export class SourceReader {
     // ==================
@@ -2001,6 +2026,56 @@ export class SourceReader {
     public _visibleInputFromTo(from: KnownSourcePosition, to: KnownSourcePosition): string {
         return this._inputFromToIn(from, to, true);
     }
+
+    /**
+     * Returns the full context of the corresponding source document before the position,
+     * up to the beginning of the given number of lines, or the beginning of the document,
+     * whichever comes first.
+     *
+     * The char at the given position is NOT included in the solution.
+     *
+     * @group Implementation: Protected for Source Positions
+     * @private
+     */
+    public _contextBeforeOf(pos: DocumentSourcePosition, lines: number): string {
+        const baseIndex: number = pos._theCharIndex;
+        const docContents: string = this._fullDocumentContentsAt(pos._theDocumentIndex);
+
+        let currentIndex: number = baseIndex;
+        let linesSeen: number = 0;
+        while (
+            currentIndex > 0 &&
+            (this._isEndOfLine(docContents[currentIndex - 1]) ? ++linesSeen : linesSeen) <= lines
+        ) {
+            currentIndex--;
+        }
+        return docContents.slice(currentIndex, baseIndex);
+    }
+
+    /**
+     * Returns the full context of the corresponding source document after the position,
+     * up to the beginning of the given number of lines, or the beginning of the document,
+     * whichever comes first.
+     *
+     * The char at the given position is the first one in the solution.
+     *
+     * @group Implementation: Protected for Source Positions
+     * @private
+     */
+    public _contextAfterOf(pos: DocumentSourcePosition, lines: number): string {
+        const baseIndex: number = pos._theCharIndex;
+        const docContents: string = this._fullDocumentContentsAt(pos._theDocumentIndex);
+
+        let currentIndex: number = baseIndex;
+        let linesSeen: number = 0;
+        while (
+            currentIndex < docContents.length &&
+            (this._isEndOfLine(docContents[currentIndex + 1]) ? ++linesSeen : linesSeen) <= lines
+        ) {
+            currentIndex++;
+        }
+        return docContents.slice(baseIndex, currentIndex + 1);
+    }
     // ------------------
     // #endregion } Implementation: Protected for Source Positions
     // ==================
@@ -2196,5 +2271,5 @@ export class SourceReader {
     // ==================
 }
 // -----------------------------------------------
-// #endregion } API: Main -- SourceReader
+// #endregion } Main definitions -- SourceReader
 // ===============================================

--- a/src/SourceReader/SourceReaderErrors.ts
+++ b/src/SourceReader/SourceReaderErrors.ts
@@ -14,7 +14,7 @@ import { SourceReaderIntl as intl } from './translations';
  * It also restores the prototype chain, as described in the
  *  {@link https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget
  *   | Typescript Handbook}.
- * @group API: Errors
+ * @group Errors
  */
 export class SourceReaderError extends Error {
     /**
@@ -35,7 +35,7 @@ export class SourceReaderError extends Error {
  * The superclass for all {@link SourceReader} errors with `operation` and `context` as
  * interpolations.
  * It constructs the corresponding interpolation.
- * @group API: Errors
+ * @group Errors
  */
 export class SourceReaderErrorBy extends SourceReaderError {
     /**
@@ -55,7 +55,7 @@ export class SourceReaderErrorBy extends SourceReaderError {
 // ===============================================
 /**
  * The error to produce when a SourceReader is called with no input (an empty object or array).
- * @group API: Errors
+ * @group Errors
  */
 export class ErrorNoInput extends SourceReaderError {
     /**
@@ -69,7 +69,7 @@ export class ErrorNoInput extends SourceReaderError {
 /**
  * The error to produce when two positions related with different readers are used to determine
  * a portion of the contents.
- * @group API: Errors
+ * @group Errors
  */
 export class ErrorUnmatchingPositionsBy extends SourceReaderErrorBy {
     /**
@@ -85,7 +85,7 @@ export class ErrorUnmatchingPositionsBy extends SourceReaderErrorBy {
 
 /**
  * The error to produce when a function that is not supposed to be used at EndOfInput is called.
- * @group API: Errors
+ * @group Errors
  */
 export class ErrorAtEndOfInputBy extends SourceReaderErrorBy {
     /**
@@ -100,7 +100,7 @@ export class ErrorAtEndOfInputBy extends SourceReaderErrorBy {
 
 /**
  * The error to produce when a function that is not supposed to be used at EndOfDocument is called.
- * @group API: Errors
+ * @group Errors
  */
 export class ErrorAtEndOfDocumentBy extends SourceReaderErrorBy {
     /**

--- a/src/SourceReader/index.ts
+++ b/src/SourceReader/index.ts
@@ -1,29 +1,74 @@
 /**
- * A {@link SourceReader} allows you to read input from some source, either one single string of
- * content or several named or indexed source strings, in such a way that each character read
- * may register its position in the source as a tuple index-line-column.
- * That is, the main problem it solves is that of calculating the position of each character
- * read by taking into account characters indicating the end-of-line.
- * It also solves the problem of input divided among several strings, as it is usually the case
+ * A {@link SourceReader} allows you to read input from some source, either one single document of
+ * content or several named or indexed source documents, in such a way that each character read
+ * registers its position in the source as a tuple index-line-column.
+ * That is, the main problem it solves is that of calculating the position of each character read
+ * by taking into account characters indicating the end-of-line.
+ * It also solves the problem of input divided among several documents, as it is usually the case
  * with source code, and it provides a couple of additional features:
- *   * to use some parts of the input as extra annotations by marking them as non visible, so
- *     the input can be read as if the annotations were not there, and
- *   * to allow the relationship of parts of the input with identifiers naming "regions", thus
- *     making it possible for external tools to identify those parts with ease.
+ *  * to use some parts of the input as extra annotations by marking them as non visible, so the
+ *    input can be read as if the annotations were not there, and
+ *  * to allow the relationship of parts of the input with identifiers naming "regions", thus
+ *    making it possible for external tools to identify those parts with ease.
  *
- * A {@link SourceReader} is created using a {@link SourceInput}, and then {@link SourcePosition}
- * can be read from it.
- * Possible interactions with a {@link SourceReader} include:
- *  - peek a character,
- *  - check if a given string occurs at the beginning of text without skipping it,
- *  - get the current position (as a {@link SourcePosition}),
- *  - detect if the end of input was reached,
- *  - skip one or more characters, and
- *  - manipulate "regions".
- * When reading from sources with multiple string of input, skipping moves from one of them to
- * the next transparently for the user (with the exception that regions are reset).
+ * A {@link SourceReader} is created using a {@link SourceInput} and then {@link SourcePosition}s,
+ * in particular {@link KnownSourcePosition}s, can be read from it.
+ * Possible interactions with a {@link SourceReader} includes:
+ *  - {@link SourceReader.peek | peek}, peeking a character,
+ *  - {@link SourceReader.startsWith | startsWith}, checking if a given strings occurs at the
+ *    beginning of the text in the current document, without skipping it,
+ *  - {@link SourceReader.getPosition | getPosition}
+ *  - {@link SourceReader.getDocumentPosition | getDocumentPosition}, getting the current position
+ *    as a {@link KnownSourcePosition} or (provided the end of input was not reached)
+ *    {@link DocumentSourcePosition}, respectively,
+ *  - {@link SourceReader.atEndOfInput | atEndOfInput}, detecting if the end of input was reached,
+ *  - {@link SourceReader.atEndOfDocument | atEndOfDocument}, detecting if the end of the current
+ *    document was reached,
+ *  - {@link SourceReader.skip | skip}, skipping one or more characters,
+ *  - {@link SourceReader.takeWhile | takeWhile}, reading some characters from the current document
+ *    based on a condition, and
+ *  - {@link SourceReader.beginRegion | beginRegion} and
+ *    {@link SourceReader.endRegion | endRegion}, manipulating "regions".
+ * When reading from sources with multiple documents of input, skipping moves inside a document
+ * until there are no more characters, then an end of document position is reached (a special
+ * position just after the last character of that document), and then a new document is started.
+ * Regions are reset at the beginning of each document.
+ * When the last document has been processed, and the last end of document has been skipped, the
+ * end of input is reached (a special position just after all the documents).
+ *
+ * A {@link SourceReader} also has a special position,
+ * {@link SourceReader.UnknownPosition | UnknownPosition}, as a static member of the class,
+ * indicating that the position is not known.
  *
  * See {@link SourceReader} documentation for more details.
+ *
+ * ## Source positions
+ *
+ * {@link SourcePosition}s conform a hierarchy of subclasses, as positions may be unknown or
+ * they may point to a particular position into a {@link SourceReader}.
+ * All {@link SourcePosition}s are created only through {@link SourceReader}.
+ * The general class is precisely {@link SourcePosition}, an abstract class to represent all
+ * possible positions.
+ * Subclasses of {@link SourcePosition} determine if the position is known or unknown, and in
+ * the case of being known, which kind of position it is.
+ * The full hierarchy is the following:
+ *   * {@link SourcePosition} (abstract)
+ *     * {@link UnknownSourcePosition}
+ *     * {@link KnownSourcePosition} (abstract)
+ *       * {@link EndOfInputSourcePosition}
+ *       * {@link DocumentSourcePosition} (abstract)
+ *         * {@link EndOfDocumentSourcePosition}
+ *         * {@link DefinedSourcePosition}
+ * The positions {@link EndOfInputSourcePosition} and {@link EndOfDocumentSourcePosition} indicate
+ * particular positions in a {@link SourceReader} that do not point to any character, but instead
+ * to the end of a document or the end of the whole input.
+ * {@link DefinedSourcePosition} are the most refined, as they point to actual characters inside a
+ * document.
+ * Consult each class for the particular interface of each one.
+ * A typical use of {@link SourcePosition} is relating nodes of an AST representation of code to
+ * particular positions in the string version of the source code (that may come from several input
+ * documents).
+ *
  * @module SourceReader
  */
 export * from './SourceReader';

--- a/src/SourceReader/translations/SourceReaderLocale.ts
+++ b/src/SourceReader/translations/SourceReaderLocale.ts
@@ -12,7 +12,7 @@
  * of this interface and place it with the current ones (those for
  * English, {@link SourceReader.en | en}, and Spanish, {@link SourceReader.es | es}).
  *
- * @group Internal: Translations
+ * @group Translations
  */
 export interface SourceReaderLocale {
     error: {

--- a/src/SourceReader/translations/SourceReaderLocaleEN.ts
+++ b/src/SourceReader/translations/SourceReaderLocaleEN.ts
@@ -8,7 +8,7 @@ import { SourceReaderLocale } from './SourceReaderLocale';
  * The locale for English language, for {@link SourceReader}.
  * It implements interface {@link SourceReaderLocale}.
  *
- * @group Internal: Translations
+ * @group Translations
  */
 export const en: SourceReaderLocale = {
     error: {

--- a/src/SourceReader/translations/SourceReaderLocaleES.ts
+++ b/src/SourceReader/translations/SourceReaderLocaleES.ts
@@ -8,7 +8,7 @@ import { SourceReaderLocale } from './SourceReaderLocale';
  * The locale for Spanish language, for {@link SourceReader}.
  * It implements interface {@link SourceReaderLocale}.
  *
- * @group Internal: Translations
+ * @group Translations
  */
 export const es: SourceReaderLocale = {
     error: {

--- a/src/SourceReader/translations/index.ts
+++ b/src/SourceReader/translations/index.ts
@@ -19,7 +19,7 @@ import { es } from './SourceReaderLocaleES';
  * It is similar to other `availableLocales`, providing locales not only for English and Spanish,
  * but also several local dialects (all defaulting to their base language).
  *
- * @group Internal: Translations
+ * @group Translations
  */
 export const availableLocales = {
     en,
@@ -69,7 +69,7 @@ export const availableLocales = {
  * It uses {@link availableLocales} to provide the locales, and defaults to English.
  * The translator is flattened to allow dot notation.
  *
- * @group Internal: Translations
+ * @group Translations
  */
 export const SourceReaderIntl = new Translator<SourceReaderLocale>(availableLocales, 'en', true);
 // #endregion } Implementation: Translations

--- a/src/Types/Subset.ts
+++ b/src/Types/Subset.ts
@@ -17,8 +17,8 @@ export type Subset<K> = {
     [attr in keyof K]?: K[attr] extends object
         ? Subset<K[attr]>
         : K[attr] extends object | null
-        ? Subset<K[attr]> | null
-        : K[attr] extends object | null | undefined
-        ? Subset<K[attr]> | null | undefined
-        : K[attr];
+          ? Subset<K[attr]> | null
+          : K[attr] extends object | null | undefined
+            ? Subset<K[attr]> | null | undefined
+            : K[attr];
 };

--- a/test/Functions/deepStringAssign.test.ts
+++ b/test/Functions/deepStringAssign.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, describe as given, expect, it } from '@jest/globals';
 
 import { Subset } from '../../src/Types';
 import { deepStringAssign } from '../../src/Functions';
@@ -11,61 +11,61 @@ interface A {
     };
 }
 
-let defaultA: A;
-let defaultAClone: A;
-let arg1: Subset<A>;
-let arg2: Subset<A>;
-let res: A;
+let originalA: A;
+let originalAClone: A;
 
-describe('deepStringAssign', () => {
+describe('In deepStringAssign', () => {
     beforeEach(() => {
-        defaultA = { a1: 'Default A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
-        defaultAClone = { a1: 'Default A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
+        originalA = { a1: 'Default A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
+        originalAClone = { a1: 'Default A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
     });
 
-    describe('one source', () => {
-        it('shallow attribute', () => {
-            res = { a1: 'User A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
-            arg1 = { a1: 'User A1' };
-            expect(deepStringAssign<A>(defaultA, arg1)).toStrictEqual(res);
+    given('One source', () => {
+        it('Correctly incorporates a shallow attribute', () => {
+            const arg1: Subset<A> = { a1: 'User A1' };
+            const res: A = { a1: 'User A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
+            expect(deepStringAssign<A>(originalA, arg1)).toStrictEqual(res);
         });
-        it('deep attribute', () => {
-            res = { a1: 'Default A1', a2: { a21: 'User A21', a22: 'Default A22' } };
-            arg1 = { a2: { a21: 'User A21' } };
-            expect(deepStringAssign<A>(defaultA, arg1)).toStrictEqual(res);
-        });
-    });
-
-    describe('several sources', () => {
-        it('one shallow, one deep', () => {
-            res = { a1: 'User A1', a2: { a21: 'Default A21', a22: 'User A22' } };
-            arg1 = { a1: 'User A1' };
-            arg2 = { a2: { a22: 'User A22' } };
-            expect(deepStringAssign(defaultA, arg1, arg2)).toStrictEqual(res);
-        });
-        it('two deep', () => {
-            res = { a1: 'Default A1', a2: { a21: 'User A21', a22: 'User A22' } };
-            arg1 = { a2: { a21: 'User A21' } };
-            arg2 = { a2: { a22: 'User A22' } };
-            expect(deepStringAssign(defaultA, arg1, arg2)).toStrictEqual(res);
-        });
-        it('two shallow, overwriting', () => {
-            res = { a1: 'User2 A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
-            arg1 = { a1: 'User A1' };
-            arg2 = { a1: 'User2 A1' };
-            expect(deepStringAssign(defaultA, arg1, arg2)).toStrictEqual(res);
+        it('Correctly incorporates a deep attribute', () => {
+            const arg1: Subset<A> = { a2: { a21: 'User A21' } };
+            const res: A = { a1: 'Default A1', a2: { a21: 'User A21', a22: 'Default A22' } };
+            expect(deepStringAssign<A>(originalA, arg1)).toStrictEqual(res);
         });
     });
 
-    describe('non interference', () => {
-        it('target not altered', () => {
-            res = deepStringAssign(defaultA, { a1: 'User A1' });
-            expect(defaultA).toStrictEqual(defaultAClone);
+    given('Several sources', () => {
+        it('Correctly incorporates one shallow and one deep attribute', () => {
+            const arg1: Subset<A> = { a1: 'User A1' };
+            const arg2: Subset<A> = { a2: { a22: 'User A22' } };
+            const res: A = { a1: 'User A1', a2: { a21: 'Default A21', a22: 'User A22' } };
+            expect(deepStringAssign(originalA, arg1, arg2)).toStrictEqual(res);
         });
-        it('sources not altered', () => {
-            arg1 = { a1: 'User A1' };
-            arg2 = { a1: 'User2 A1' };
-            res = deepStringAssign(defaultA, arg1, arg2);
+
+        it('Correctly incorporates two deep attributes', () => {
+            const arg1: Subset<A> = { a2: { a21: 'User A21' } };
+            const arg2: Subset<A> = { a2: { a22: 'User A22' } };
+            const res: A = { a1: 'Default A1', a2: { a21: 'User A21', a22: 'User A22' } };
+            expect(deepStringAssign(originalA, arg1, arg2)).toStrictEqual(res);
+        });
+
+        it('Correctly incorporates two shallow attributes, overwriting', () => {
+            const arg1: Subset<A> = { a1: 'User A1' };
+            const arg2: Subset<A> = { a1: 'User2 A1' };
+            const res: A = { a1: 'User2 A1', a2: { a21: 'Default A21', a22: 'Default A22' } };
+            expect(deepStringAssign(originalA, arg1, arg2)).toStrictEqual(res);
+        });
+    });
+
+    given('Someone else uses deepStringAssign', () => {
+        it('with one source, target is not altered by that use (non-interference)', () => {
+            deepStringAssign(originalA, { a1: 'User A1' });
+            expect(originalA).toStrictEqual(originalAClone);
+        });
+
+        it('with two sources, target is not altered by that use (non-interference)', () => {
+            const arg1: Subset<A> = { a1: 'User A1' };
+            const arg2: Subset<A> = { a1: 'User2 A1' };
+            deepStringAssign(originalA, arg1, arg2);
             expect(arg1).toStrictEqual({ a1: 'User A1' });
             expect(arg2).toStrictEqual({ a1: 'User2 A1' });
         });


### PR DESCRIPTION
Added operations contextBefore and contextAfter to DocumentPositions. 
Improved documentation.
Test for deepStringAssign also improved.

close #31
